### PR TITLE
修正获取关注者详细信息可能出现的错误

### DIFF
--- a/Wechat/WechatUser.php
+++ b/Wechat/WechatUser.php
@@ -93,6 +93,7 @@ class WechatUser extends Common {
         }
         $result = Tools::httpGet(self::API_URL_PREFIX . self::USER_INFO_URL . "access_token={$this->access_token}&openid={$openid}");
         if ($result) {
+            $result = substr(str_replace('\"', '"', json_encode($result)), 1, -1);
             $json = json_decode($result, true);
             if (isset($json['errcode'])) {
                 $this->errCode = $json['errcode'];


### PR DESCRIPTION
如用户信息某一字段存在特殊字符，这导致JSON_DECODE返回NULL，现对微信服务器请求结果进行编码替换后在进行解析。

示例代码：
$str = '{"subscribe":1,"openid":"o7TC3v_zvuxmuRPU6YeBOD6cz0Ng","nickname":"文文","sex":2,"language":"zh_CN","city":"S�Y4","province":"Q���Sä","country":"","headimgurl":"http://wx.qlogo.cn/mmopen/0dhrpQA7Vn64H2u2zApyiaicEg4hk0UCIqrJP0EcRDh1z108ARaaWUYIDfmLvBXicxGpo4uWej1PjsdMZcWIdPQ7TJehRnLWaJD/0","subscribe_time":1482894792,"remark":"","groupid":0,"tagid_list":[]}';

json_decode($str, true); 返回NULL 主要原因是city字段含有特殊符合或表情符号