### PR TITLE
Update WechatPay.php

### DIFF
--- a/Wechat/WechatPay.php
+++ b/Wechat/WechatPay.php
@@ -202,10 +202,11 @@ class WechatPay {
      * @param string $goods_tag 商品标记，代金券或立减优惠功能的参数
      * @return bool|string
      */
-    public function getPrepayId($openid, $body, $out_trade_no, $total_fee, $notify_url, $trade_type = "JSAPI", $goods_tag = null) {
+    public function getPrepayId($openid, $body, $out_trade_no, $total_fee, $notify_url, $trade_type = "JSAPI", $goods_tag = null, $fee_type = 'CNY') {
         $postdata = array(
             "body"             => $body,
             "out_trade_no"     => $out_trade_no,
+            "fee_type"         => $fee_type,
             "total_fee"        => $total_fee,
             "notify_url"       => $notify_url,
             "trade_type"       => $trade_type,
@@ -230,10 +231,11 @@ class WechatPay {
      * @param string $goods_tag 商品标记，代金券或立减优惠功能的参数
      * @return bool|string
      */
-    public function getQrcPrepayId($openid, $body, $out_trade_no, $total_fee, $notify_url, $goods_tag = null) {
+    public function getQrcPrepayId($openid, $body, $out_trade_no, $total_fee, $notify_url, $goods_tag = null, $fee_type = 'CNY') {
         $postdata = array(
             "body"             => $body,
             "out_trade_no"     => $out_trade_no,
+            "fee_type"         => $fee_type,
             "total_fee"        => $total_fee,
             "notify_url"       => $notify_url,
             "trade_type"       => 'NATIVE',


### PR DESCRIPTION
调用统一下单接口的函数中增加货币种类fee_type参数的传递，以兼容境外商户的外币微信支付。参数放在最后并默认值‘CNY’以兼容原来的调用方式。