### PR TITLE
兼容H5支付的修改

### DIFF
--- a/Wechat/WechatPay.php
+++ b/Wechat/WechatPay.php
@@ -281,7 +281,7 @@ class WechatPay
         if (false === $this->_parseResult($result)) {
             return false;
         }
-        return in_array($trade_type, array('JSAPI', 'APP')) ? $result['prepay_id'] : $result['code_url'];
+        return in_array($trade_type, array('JSAPI', 'APP')) ? $result['prepay_id'] : ($trade_type === 'MWEB' ? $result['mweb_url'] : $result['code_url']);
     }
 
     /**


### PR DESCRIPTION
修改getPrepayId()，兼容trade_type='MWEB'时返回参数mweb_url的情况，以支持H5支付。